### PR TITLE
fix(notifications): restore dropdown rendering and show ad id

### DIFF
--- a/src/components/Notifications/NotificationDropdown.js
+++ b/src/components/Notifications/NotificationDropdown.js
@@ -123,9 +123,9 @@ const NotificationDropdown = props => {
     queryKey: ['fetchNotifications'],
     queryFn: fetchNotifications,
     initialPageParam: 0,
-    getNextPageParam: (lastPage, pages) => lastPage?.current_page,
-    getNextPageParam: (lastPage, allPages) => {
-      return lastPage.current_page < lastPage.last_page ? lastPage?.current_page : undefined
+    getNextPageParam: (lastPage) => {
+      if (!lastPage) return undefined
+      return lastPage.current_page < lastPage.last_page ? lastPage.current_page : undefined
     },
     refetchInterval: 10000,
     refetchIntervalInBackground: true
@@ -133,7 +133,9 @@ const NotificationDropdown = props => {
 
   const { data: unReadNotificationCount } = useQuery({
     queryKey: ['unReadNotificationCount'],
-    queryFn: unReadNotification
+    queryFn: unReadNotification,
+    refetchInterval: 10000,
+    refetchIntervalInBackground: true
   })
 
   useEffect(() => {
@@ -238,61 +240,59 @@ const NotificationDropdown = props => {
             <CustomLoader />
           ) : status === 'error' ? (
             <MenuItem disableRipple disableTouchRipple>
-              {error.message}
+              {error?.message || t('no_notifications')}
             </MenuItem>
-          ) : data?.pages.length > 0 ? (
-            data?.pages.map((page, index) =>
-              page?.items.length > 0 ? (
-                page.items.map((notification, index) => (
-                  <MenuItem
-                    key={index}
-                    sx={{ display: 'flex', flexDirection: 'column' }}
-                    disableRipple
-                    disableTouchRipple
-                    onClick={() => handleNotificationClick(notification)}
-                  >
-                    <Box sx={{ width: '100%', display: 'flex', alignItems: 'center' }}>
-                      {/*<RenderAvatar notification={notification} />*/}
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          p: 3,
-                          mx: 1,
-                          borderRadius: '50%',
-                          backgroundColor: theme.palette.background.default
-                        }}
-                      >
-                        <Icon icon={'tabler:ad-circle'} fontSize={'1.5rem'} />
-                      </Box>
-                      <Box
-                        sx={{
-                          mr: 4,
-                          ml: 2.5,
-                          flex: '1 1',
-                          display: 'flex',
-                          overflow: 'hidden',
-                          flexDirection: 'column'
-                        }}
-                      >
-                        <MenuItemTitle>{notification.title}</MenuItemTitle>
-                        <MenuItemSubtitle variant='body2'>{notification.body}</MenuItemSubtitle>
-                        {/*<MenuItemSubtitle variant='body2' sx={{display: 'flex', justifyContent: 'end', mt: 2}}>{notification.created_at}</MenuItemSubtitle>*/}
-                      </Box>
+          ) : (data?.pages?.some(page => page?.items?.length > 0)) ? (
+            data.pages.map((page, pageIndex) =>
+              (page?.items || []).map((notification, itemIndex) => (
+                <MenuItem
+                  key={notification?.id ?? `${pageIndex}-${itemIndex}`}
+                  sx={{ display: 'flex', flexDirection: 'column' }}
+                  disableRipple
+                  disableTouchRipple
+                  onClick={() => handleNotificationClick(notification)}
+                >
+                  <Box sx={{ width: '100%', display: 'flex', alignItems: 'center' }}>
+                    {/*<RenderAvatar notification={notification} />*/}
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        p: 3,
+                        mx: 1,
+                        borderRadius: '50%',
+                        backgroundColor: theme.palette.background.default
+                      }}
+                    >
+                      <Icon icon={'tabler:ad-circle'} fontSize={'1.5rem'} />
                     </Box>
-                    <Box sx={{ display: 'flex', justifyContent: 'end', mt: 2, width: '100%' }}>
-                      <Typography variant='body2' sx={{ color: 'text.disabled' }}>
-                        {notification.created_at}
-                      </Typography>
+                    <Box
+                      sx={{
+                        mr: 4,
+                        ml: 2.5,
+                        flex: '1 1',
+                        display: 'flex',
+                        overflow: 'hidden',
+                        flexDirection: 'column'
+                      }}
+                    >
+                      <MenuItemTitle>{notification.title}</MenuItemTitle>
+                      <MenuItemSubtitle variant='body2'>{notification.body}</MenuItemSubtitle>
+                      {notification.target_type === 5 && notification.target ? (
+                        <MenuItemSubtitle variant='caption' sx={{ color: 'text.secondary', mt: 1 }}>
+                          {`${t('ad_id')}: #${notification.target}`}
+                        </MenuItemSubtitle>
+                      ) : null}
                     </Box>
-                  </MenuItem>
-                ))
-              ) : (
-                <MenuItem key={index} disableRipple disableTouchRipple>
-                  {t('no_notifications')}
+                  </Box>
+                  <Box sx={{ display: 'flex', justifyContent: 'end', mt: 2, width: '100%' }}>
+                    <Typography variant='body2' sx={{ color: 'text.disabled' }}>
+                      {notification.created_at}
+                    </Typography>
+                  </Box>
                 </MenuItem>
-              )
+              ))
             )
           ) : (
             <MenuItem disableRipple disableTouchRipple>

--- a/src/components/Notifications/notificationsServices.js
+++ b/src/components/Notifications/notificationsServices.js
@@ -20,12 +20,14 @@ export const fetchNotifications = async (page) => {
       }
     })
 
-    return response.data.data
-    // setRows(response.data.data)
-    // setLoading(false)
+    const data = response.data?.data
+    return {
+      items: Array.isArray(data?.items) ? data.items : (Array.isArray(data) ? data : []),
+      current_page: data?.current_page ?? 1,
+      last_page: data?.last_page ?? 1,
+    }
   } catch (err) {
-    toast.error(err.response?.data?.message)
-    // setLoading(false)
+    return { items: [], current_page: 1, last_page: 1 }
   }
 }
 
@@ -51,7 +53,7 @@ export const readNotifications = async () => {
 
 export const unReadNotification = async () => {
   try {
-    const response = await axios.get(`${process.env.NEXT_PUBLIC_API_KEY}user/notifications/unread-count`, 
+    const response = await axios.get(`${process.env.NEXT_PUBLIC_API_KEY}user/notifications/unread-count`,
     {
       headers: {
         'Authorization': getCookie('token'),
@@ -59,9 +61,9 @@ export const unReadNotification = async () => {
       }
     })
 
-    return response.data.data?.count
+    return response.data.data?.count ?? 0
   } catch (err) {
-    toast.error(err.response?.data?.message)
+    return 0
   }
 }
 

--- a/src/lang/ar.json
+++ b/src/lang/ar.json
@@ -173,6 +173,7 @@
   "notifications": "الإشعارات",
   "no_notifications": "لا يوجد إشعارات",
   "load_more": "المزيد",
+  "ad_id": "رقم الإعلان",
   "special_flag": "جملة مميزة",
   "expert_transactions": "عمليات المفسرين",
   "commission_value": "قيمة العمولة",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -169,6 +169,7 @@
   "notifications": "Notifications",
   "no_notifications": "No Notifications",
   "load_more": "Load More",
+  "ad_id": "Ad ID",
   "blogs": "Blogs",
   "pages": "Pages",
   "banners": "Banners",


### PR DESCRIPTION
- Return a safe default shape from fetchNotifications/unReadNotification on error so background polling cannot break the dropdown or spam toasts every 10s
- Deduplicate getNextPageParam and guard pagination against undefined pages
- Use notification.id as React key and tolerate missing pages/items in the render branch
- Refetch the unread count on the same 10s interval as the list
- Display the ad id under the body when target_type === 5, with ad_id translations in en/ar