### PR TITLE
fix(notifications): satisfy newline-before-return lint rule

### DIFF
--- a/src/components/Notifications/NotificationDropdown.js
+++ b/src/components/Notifications/NotificationDropdown.js
@@ -124,7 +124,10 @@ const NotificationDropdown = props => {
     queryFn: fetchNotifications,
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {
-      if (!lastPage) return undefined
+      if (!lastPage) {
+        return undefined
+      }
+
       return lastPage.current_page < lastPage.last_page ? lastPage.current_page : undefined
     },
     refetchInterval: 10000,

--- a/src/components/Notifications/notificationsServices.js
+++ b/src/components/Notifications/notificationsServices.js
@@ -21,6 +21,7 @@ export const fetchNotifications = async (page) => {
     })
 
     const data = response.data?.data
+
     return {
       items: Array.isArray(data?.items) ? data.items : (Array.isArray(data) ? data : []),
       current_page: data?.current_page ?? 1,


### PR DESCRIPTION
Insert the blank line ESLint expects before each `return` that isn't the first statement of its block: before the multiline return in fetchNotifications and between the early-return and the main return in getNextPageParam.